### PR TITLE
feat: implementar verificación de stock para insumos y mostrar cartel…

### DIFF
--- a/docs/STOCK_INSUMOS_IMPLEMENTATION.md
+++ b/docs/STOCK_INSUMOS_IMPLEMENTATION.md
@@ -1,0 +1,64 @@
+# Implementación de Verificación de Stock para Insumos
+
+## Resumen de Cambios Realizados
+
+Se implementó la funcionalidad para verificar el stock de artículos insumo (bebidas, etc.) y mostrar el cartel "Sin stock de insumos" cuando no hay stock suficiente.
+
+## Backend
+
+### 1. ArticuloInsumoService.java
+
+- **Método agregado**: `puedeVenderse(Long id)`
+  - Verifica si un insumo tiene stock suficiente (stockActual > 0)
+  - Ubicación: Al final de la clase, antes del cierre
+
+### 2. ArticuloInsumoController.java
+
+- **Endpoint agregado**: `GET /api/insumos/{id}/can-be-sold`
+  - Retorna `boolean` indicando si el insumo puede venderse
+  - Ubicación: Junto a los otros métodos `@GetMapping`
+
+## Frontend
+
+### 1. articuloInsumoService.ts
+
+- **Función agregada**: `canBeSold(id: number): Promise<boolean>`
+  - Consulta el endpoint `/api/insumos/{id}/can-be-sold`
+  - Maneja errores retornando `false` por defecto
+
+### 2. ProductProvider.tsx
+
+- **Función modificada**: `checkSingleProductAvailability`
+  - Ahora detecta si es insumo o manufacturado
+  - Usa `canBeSold` para insumos y `canBeManufactured` para manufacturados
+- **Función modificada**: `fetchAllData`
+  - Ahora verifica stock inicial tanto de manufacturados como de insumos
+
+### 3. CardProducto.tsx
+
+- **Cartel mejorado**: Ahora muestra "Sin stock de insumos" para cualquier artículo sin disponibilidad
+- **Botón deshabilitado**: Se deshabilita para cualquier artículo sin stock (no solo manufacturados)
+
+### 4. ModalProducto.tsx
+
+- **Mismos cambios** que CardProducto.tsx para consistencia
+
+## Comportamiento Esperado
+
+1. **Insumos con stock > 0**: Se muestran normales, botón habilitado
+2. **Insumos con stock = 0**:
+
+   - Aparece cartel "Sin stock de insumos"
+   - Botón "Agregar al carrito" deshabilitado en gris
+   - Tooltip indica que no hay stock
+
+3. **Manufacturados sin insumos suficientes**:
+   - Misma lógica que antes (sin cambios)
+
+## Verificación
+
+Para probar la funcionalidad:
+
+1. Crear un insumo "no para elaborar" (ej: bebida) con stock 0
+2. El insumo debe aparecer en el landing con el cartel "Sin stock de insumos"
+3. El botón debe estar deshabilitado y en gris

--- a/src/modules/HU9_10_Landing_Busqueda/articulos/CardProducto.tsx
+++ b/src/modules/HU9_10_Landing_Busqueda/articulos/CardProducto.tsx
@@ -7,15 +7,6 @@ type ProductProps = {
   setProductoModal: (producto: ArticuloManufacturado | ArticuloInsumo | null) => void;
 };
 
-/**
- * Determina si un artículo es de tipo ArticuloManufacturado
- */
-const isArticuloManufacturado = (
-  articulo: ArticuloInsumo | ArticuloManufacturado
-): articulo is ArticuloManufacturado => {
-  return 'categoriaId' in articulo && 'descripcion' in articulo;
-};
-
 export const CardProducto = ({ articulo, setProductoModal }: ProductProps) => {
   const productAvailability = useProductStore((state) => state.productAvailability);
 
@@ -44,19 +35,19 @@ export const CardProducto = ({ articulo, setProductoModal }: ProductProps) => {
               className="object-cover w-full h-full"
             />
           </picture>{' '}
-          {isArticuloManufacturado(articulo) && !isAvailable && (
+          {!isAvailable && (
             <div className="absolute top-2 right-2 bg-black/70 text-white text-xs px-2 py-1 rounded">
               Sin stock de insumos
             </div>
           )}
-        </div>
+        </div>{' '}
         <BtnAgregarCarrito
           position={'right'}
           articulo={articulo}
           cantidadProducto={1}
           setCantidadProducto={() => {}}
           onClose={() => {}}
-          disabledOverride={isArticuloManufacturado(articulo) && !isAvailable}
+          disabledOverride={!isAvailable}
         />
       </div>
       <div className="p-4 text-left">

--- a/src/modules/HU9_10_Landing_Busqueda/articulos/ModalProducto.tsx
+++ b/src/modules/HU9_10_Landing_Busqueda/articulos/ModalProducto.tsx
@@ -69,7 +69,7 @@ export const ModalProducto: React.FC<Props> = ({ articulo = null, isOpen, onClos
               >
                 Volver
               </button>{' '}
-              {isArticuloManufacturado(articulo) && !isAvailable && (
+              {!isAvailable && (
                 <div className="bg-negro/80 text-white text-nowrap text-xs px-3 py-1 rounded absolute bottom-16 right-3">
                   Sin stock de insumos
                 </div>
@@ -79,7 +79,7 @@ export const ModalProducto: React.FC<Props> = ({ articulo = null, isOpen, onClos
                 cantidadProducto={cantidadProducto}
                 setCantidadProducto={setCantidadProducto}
                 onClose={onClose}
-                disabledOverride={isArticuloManufacturado(articulo) && !isAvailable}
+                disabledOverride={!isAvailable}
               />
             </div>
           </aside>

--- a/src/shared/providers/ProductProvider.tsx
+++ b/src/shared/providers/ProductProvider.tsx
@@ -8,7 +8,7 @@ import {
   getAllArticuloManufacturados,
   canBeManufactured,
 } from '../services/articuloManufacturadoService';
-import { getAllArticuloInsumoNoEsParaElaborar } from '../services/articuloInsumoService';
+import { getAllArticuloInsumoNoEsParaElaborar, canBeSold } from '../services/articuloInsumoService';
 import {
   getAllPromocionesVigentes,
   normalizePromociones,
@@ -136,11 +136,37 @@ export const useProductStore = create<ProductState>((set, get) => ({
         [productId]: available,
       },
     }));
-  },
-  // Nueva función para verificar disponibilidad de un producto específico en background
+  }, // Nueva función para verificar disponibilidad de un producto específico en background
   checkSingleProductAvailability: async (productId: number) => {
     try {
-      const available = await canBeManufactured(productId);
+      // Buscar si es un artículo manufacturado
+      const { allProducts } = get();
+      const product = allProducts.find((p) => p.id === productId);
+
+      let available = false;
+
+      if (product) {
+        // Verificar si es ArticuloInsumo (tiene stockActual)
+        if ('stockActual' in product) {
+          // Es un insumo, verificar stock
+          available = await canBeSold(productId);
+        } else {
+          // Es un manufacturado, verificar si puede fabricarse
+          available = await canBeManufactured(productId);
+        }
+      } else {
+        // Si no encontramos el producto, intentar ambos endpoints
+        try {
+          available = await canBeManufactured(productId);
+        } catch {
+          try {
+            available = await canBeSold(productId);
+          } catch {
+            available = false;
+          }
+        }
+      }
+
       get().updateProductAvailability(productId, available);
     } catch (error) {
       console.error(`Error checking availability for product ${productId}:`, error);
@@ -254,18 +280,10 @@ export const useProductStore = create<ProductState>((set, get) => ({
       const combinedProducts = [...manufacturadosData, ...insumosData] as (
         | ArticuloManufacturado
         | ArticuloInsumo
-      )[];
-
-      // Verificar disponibilidad inicial para todos los productos manufacturados
+      )[]; // Verificar disponibilidad inicial para todos los productos
       const initialAvailability: Record<number, boolean> = {};
-      // Primero marcamos todos los insumos como disponibles
-      insumosData.forEach((insumo: ArticuloInsumo) => {
-        if (insumo.id) {
-          initialAvailability[insumo.id] = true;
-        }
-      });
 
-      // Verificar disponibilidad de manufacturados en paralelo
+      // Verificar disponibilidad de manufacturados e insumos en paralelo
       const manufacturadosChecks = manufacturadosData.map(
         async (manufacturado: ArticuloManufacturado) => {
           if (manufacturado.id) {
@@ -280,8 +298,21 @@ export const useProductStore = create<ProductState>((set, get) => ({
         }
       );
 
+      // Verificar disponibilidad de insumos en paralelo
+      const insumosChecks = insumosData.map(async (insumo: ArticuloInsumo) => {
+        if (insumo.id) {
+          try {
+            const available = await canBeSold(insumo.id);
+            initialAvailability[insumo.id] = available;
+          } catch (error) {
+            console.error(`Error checking availability for insumo ${insumo.id}:`, error);
+            initialAvailability[insumo.id] = false;
+          }
+        }
+      });
+
       // Esperar todas las verificaciones
-      await Promise.all(manufacturadosChecks); // Ordenar productos por disponibilidad dentro de cada categoría
+      await Promise.all([...manufacturadosChecks, ...insumosChecks]); // Ordenar productos por disponibilidad dentro de cada categoría
       const sortedProducts = [...combinedProducts].sort((a, b) => {
         const catA = getArticuloCategoriaId(a);
         const catB = getArticuloCategoriaId(b);

--- a/src/shared/services/articuloInsumoService.ts
+++ b/src/shared/services/articuloInsumoService.ts
@@ -155,3 +155,14 @@ export const getAllArticuloInsumoByCategoriaWithDeleted = async (id: number) => 
   const response = await axiosInstance.get(`${API_BASE_URL}/categoria/${id}/with-deleted`);
   return response.data;
 };
+
+// 🆕 Consultar si un insumo puede venderse (tiene stock suficiente)
+export const canBeSold = async (id: number): Promise<boolean> => {
+  try {
+    const response = await axiosInstance.get(`${API_BASE_URL}/${id}/can-be-sold`);
+    return response.data;
+  } catch (error) {
+    console.error('Error al consultar stock del insumo:', error);
+    return false; // Si hay error, considerar que no se puede vender
+  }
+};


### PR DESCRIPTION
… "Sin stock"

## Cambios realizados:

### 🔧 Servicios
- **articuloInsumoService.ts**: Agregada función `canBeSold()` para verificar stock de insumos via endpoint `/api/insumos/{id}/can-be-sold`

### 📦 Providers
- **ProductProvider.tsx**:
  - Importado `canBeSold` desde articuloInsumoService
  - Modificado `checkSingleProductAvailability()` para detectar tipo de artículo (insumo vs manufacturado) y usar endpoint correspondiente
  - Actualizado `fetchAllData()` para verificar stock inicial de insumos usando `canBeSold()` en paralelo con manufacturados

### 🎨 Componentes UI
- **CardProducto.tsx**:
  - Removida función `isArticuloManufacturado()` no utilizada
  - Modificado cartel "Sin stock de insumos" para mostrar en cualquier artículo sin disponibilidad (no solo manufacturados)
  - Actualizado `disabledOverride` del `BtnAgregarCarrito` para aplicar a cualquier artículo sin stock

### 📚 Documentación
- **docs/STOCK_INSUMOS_IMPLEMENTATION.md**: Documentación completa de la implementación

## Resultado:
- Los insumos "no para elaborar" (bebidas, etc.) sin stock ahora muestran cartel "Sin stock de insumos"
- Botón "Agregar al carrito" se deshabilita automáticamente para artículos sin stock
- Verificación funciona tanto para manufacturados como para insumos
- Consistencia visual en toda la aplicación