### PR TITLE
feat: mejorar UX de campos de cantidad en modales de selección

### DIFF
--- a/src/modules/HU20_CRUD_CategoriasPadresInsumos/components/SeccionUnidadesMedida.tsx
+++ b/src/modules/HU20_CRUD_CategoriasPadresInsumos/components/SeccionUnidadesMedida.tsx
@@ -78,10 +78,18 @@ const SeccionUnidadesMedida = () => {
       label: 'Acciones',
       key: 'acciones',
       render: (row: any) => {
-        const soloVer = showDeleted && row.eliminado;
+        // Agregar propiedad eliminado si no existe (para elementos de deletedUnidades)
+        const elementoConEliminado = {
+          ...row,
+          eliminado: deletedUnidades.some((d) => d.id === row.id),
+        };
+
+        // Solo mostrar "ver" si está en vista eliminados pero no permitir editar elementos activos en esa vista
+        const soloVer = showDeleted && !elementoConEliminado.eliminado;
+
         return (
           <ButtonsTable
-            el={row}
+            el={elementoConEliminado}
             handleDelete={handleDelete}
             setOpenModal={setOpenModal}
             setSelectedItem={setSelectedUnidad}

--- a/src/modules/HU22_CRUDArticulos/components/ModalEditarCantidadInsumo.tsx
+++ b/src/modules/HU22_CRUDArticulos/components/ModalEditarCantidadInsumo.tsx
@@ -45,8 +45,9 @@ const ModalEditarCantidadInsumo: React.FC<ModalEditarCantidadInsumoProps> = ({
             type="number"
             min={1}
             className="w-full border rounded px-3 py-2 bg-gray-100 text-base text-negro"
-            value={valor}
-            onChange={(e) => setValor(Number(e.target.value))}
+            value={valor > 0 ? valor : ''}
+            onChange={(e) => setValor(Number(e.target.value) || 0)}
+            placeholder="Ingrese la cantidad"
             autoFocus
           />
         </div>

--- a/src/modules/HU22_CRUDArticulos/components/ModalSeleccionInsumos.tsx
+++ b/src/modules/HU22_CRUDArticulos/components/ModalSeleccionInsumos.tsx
@@ -86,26 +86,20 @@ const ModalSeleccionInsumos: React.FC<ModalSeleccionInsumosProps> = ({
       if (newMap.has(insumo.id!)) {
         newMap.delete(insumo.id!);
       } else {
-        newMap.set(insumo.id!, 0); // Cantidad por defecto
+        newMap.set(insumo.id!, 0); // Inicializar en 0 pero mostrar como vacío
       }
       return newMap;
     });
   };
 
   const handleCantidadChange = (insumoId: number, cantidad: number) => {
-    if (cantidad <= 0) {
-      setSelectedInsumos((prev) => {
-        const newMap = new Map(prev);
-        newMap.delete(insumoId);
-        return newMap;
-      });
-    } else {
-      setSelectedInsumos((prev) => {
-        const newMap = new Map(prev);
-        newMap.set(insumoId, cantidad);
-        return newMap;
-      });
-    }
+    // Siempre mantener el insumo seleccionado, incluso si la cantidad es 0
+    // Solo actualizar la cantidad sin eliminar de la selección
+    setSelectedInsumos((prev) => {
+      const newMap = new Map(prev);
+      newMap.set(insumoId, cantidad >= 0 ? cantidad : 0);
+      return newMap;
+    });
   };
 
   // Verificar si todos los insumos seleccionados tienen cantidad > 0
@@ -231,14 +225,14 @@ const ModalSeleccionInsumos: React.FC<ModalSeleccionInsumosProps> = ({
                             </label>
                             <input
                               type="number"
-                              value={cantidad}
+                              value={cantidad > 0 ? cantidad : ''}
                               onChange={(e) =>
                                 handleCantidadChange(insumo.id!, Number(e.target.value))
                               }
                               min="0.01"
                               step="0.01"
                               className="w-full border rounded px-2 py-1 text-sm"
-                              placeholder="Cantidad"
+                              placeholder="Ingrese la cantidad"
                               onClick={(e) => e.stopPropagation()}
                             />
                           </div>

--- a/src/modules/HU25_Promociones/components/ModalSeleccionarArticulos.tsx
+++ b/src/modules/HU25_Promociones/components/ModalSeleccionarArticulos.tsx
@@ -123,7 +123,7 @@ const ModalSeleccionarArticulos: React.FC<ModalSeleccionarArticulosProps> = ({
       if (newMap.has(articulo.id!)) {
         newMap.delete(articulo.id!);
       } else {
-        newMap.set(articulo.id!, 0); // Cantidad por defecto
+        newMap.set(articulo.id!, 0); // Inicializar en 0 pero mostrar como vacío
       }
       return newMap;
     });
@@ -133,19 +133,13 @@ const ModalSeleccionarArticulos: React.FC<ModalSeleccionarArticulosProps> = ({
     // Redondear a entero ya que solo hay manufacturados e insumos no para elaborar
     const cantidadFinal = Math.floor(cantidad);
 
-    if (cantidadFinal <= 0) {
-      setSelectedArticulos((prev) => {
-        const newMap = new Map(prev);
-        newMap.delete(articuloId);
-        return newMap;
-      });
-    } else {
-      setSelectedArticulos((prev) => {
-        const newMap = new Map(prev);
-        newMap.set(articuloId, cantidadFinal);
-        return newMap;
-      });
-    }
+    // Siempre mantener el artículo seleccionado, incluso si la cantidad es 0
+    // Solo actualizar la cantidad sin eliminar de la selección
+    setSelectedArticulos((prev) => {
+      const newMap = new Map(prev);
+      newMap.set(articuloId, cantidadFinal >= 0 ? cantidadFinal : 0);
+      return newMap;
+    });
   };
 
   // Verificar si todos los artículos seleccionados tienen cantidad > 0
@@ -264,14 +258,14 @@ const ModalSeleccionarArticulos: React.FC<ModalSeleccionarArticulosProps> = ({
                             <label className="block text-xs font-medium mb-1">Cantidad</label>
                             <input
                               type="number"
-                              value={cantidad}
+                              value={cantidad > 0 ? cantidad : ''}
                               onChange={(e) =>
                                 handleCantidadChange(articulo.id!, Number(e.target.value))
                               }
                               min="1"
                               step="1"
                               className="w-full border rounded px-2 py-1 text-sm"
-                              placeholder="Cantidad"
+                              placeholder="Ingrese la cantidad"
                               onClick={(e) => e.stopPropagation()}
                             />
                           </div>


### PR DESCRIPTION
- ModalSeleccionarArticulos: mantener selección al editar cantidad
- ModalSeleccionInsumos: mantener selección al editar cantidad
- ModalEditarCantidadInsumo: mostrar placeholder en lugar de 0
- SeccionUnidadesMedida: corregir botón restaurar en vista eliminados

Cambios específicos:
• Los campos de cantidad ya no muestran "0" por defecto • Placeholder "Ingrese la cantidad" en campos vacíos • Evitar deselección accidental al borrar/editar cantidades • Mantener artículos/insumos seleccionados durante edición • Corregir lógica de botones restaurar en tablas con baja lógica

Mejora la experiencia del usuario al eliminar comportamientos inesperados